### PR TITLE
Fix ancyterm permission on docker

### DIFF
--- a/ancypwn-docker/16.04/Dockerfile
+++ b/ancypwn-docker/16.04/Dockerfile
@@ -41,6 +41,7 @@ RUN cd ~/ && \
 ENV LANG C.UTF-8
 
 COPY ./ancyterm.py /usr/local/bin/ancyterm
+RUN chmod +x /usr/local/bin/ancyterm
 
 VOLUME ["/pwn"]
 WORKDIR /pwn

--- a/ancypwn-docker/18.04/Dockerfile
+++ b/ancypwn-docker/18.04/Dockerfile
@@ -42,6 +42,7 @@ RUN cd ~/ && \
 ENV LANG C.UTF-8
 
 COPY ./ancyterm.py /usr/local/bin/ancyterm
+RUN chmod +x /usr/local/bin/ancyterm
 
 VOLUME ["/pwn"]
 WORKDIR /pwn

--- a/ancypwn-docker/18.10/Dockerfile
+++ b/ancypwn-docker/18.10/Dockerfile
@@ -41,6 +41,7 @@ RUN cd ~/ && \
 ENV LANG C.UTF-8
 
 COPY ./ancyterm.py /usr/local/bin/ancyterm
+RUN chmod +x /usr/local/bin/ancyterm
 
 VOLUME ["/pwn"]
 WORKDIR /pwn


### PR DESCRIPTION
Got a permission denied while executing `ancyterm` from self build docker image, turns out the execute permission isn't set. Also, I just read the README.md update for docker image from Auxy223 and the execute permission for ancyterm already fixed on that. Is it built from the same Dockerfile on this repo?